### PR TITLE
Feat/updated dependencies and tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Example",
+      "request": "launch",
+      "type": "dart",
+      "cwd": "example",
+      "program": "lib/main.dart"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 5.3.0
+* Added `EnvironmentDetails` as a typed wrapper for runtime environment metadata.
+* Added `PlatformDetail.environmentDetails()` to get compact platform, model, locale, and `PlatformType` data.
+* Exported `EnvironmentDetails` from the public API.
+* Updated example app to render the new environment details on screen.
+* Added tests for `environmentDetails()` success and fallback flows.
+
 ## 5.2.0
 * Updated device_info_plus and dio dependencies.
 * Fixed tests.

--- a/README.md
+++ b/README.md
@@ -32,15 +32,21 @@ It provides a unified and consistent API for checking the platform your app is r
 
 - ✅ Unified API across all platforms (including web).
 - ✅ Clear separation between **platform type** and **platform group**.
-- ✅ Singleton behavior via factory constructor.
+- ✅ Static API with simple access from `PlatformDetail`.
 - ✅ No need to manually check `kIsWeb` or rely on partial solutions.
+- ✅ Typed runtime environment details (`platform`, `deviceModel`, `locale`, `platformType`).
 - ✅ Detect private and public IP addresses.
 - ✅ Detect device theme (light or dark).
 
 ## Getting Started
 
-The recommended way to use the library is to call the static members of the [PlatformDetail] class.  
-Thanks to a factory constructor, multiple instances are not created — a singleton is used internally.
+The recommended way to use the library is to call the static members of the [PlatformDetail] class.
+
+### Run the Example
+
+The `example` app now shows device info, network info and `EnvironmentDetails` on screen.
+
+If you use VS Code, you can launch it with the `Flutter Example` debug configuration (`cwd: example`, `program: lib/main.dart`).
 
 ---
 
@@ -211,6 +217,29 @@ This will return something like this:
 - Linux: Fedora 17 (Beefy Miracle)
 - Windows: Windows 10 Home (1903)
 - MacOS: macOS 13.5, MacBook Pro
+---
+
+### Get compact environment details
+If you need a typed and lightweight payload with platform, model and locale, use `environmentDetails()`:
+
+```dart
+void main() async {
+  final details = await PlatformDetail.environmentDetails();
+
+  print(details.platformType); // PlatformType.android
+  print(details.platform); // android 14
+  print(details.deviceModel); // Google Pixel 8
+  print(details.locale); // en-US
+}
+```
+
+This returns an `EnvironmentDetails` object with these fields:
+- `platformType`: `PlatformType`
+- `platform`: `String`
+- `deviceModel`: `String`
+- `locale`: `String`
+
+The `example` app includes a section that renders these values on screen.
 ---
 
 ### Light/Dark Mode

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -41,52 +41,84 @@ class _MyHomePageState extends State<MyHomePage> {
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         title: Text(widget.title),
       ),
-      body: Center(
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            FutureBuilder(
-                future: PlatformDetail.deviceInfoDetails(),
-                builder: (context, snapshot) {
-                  if (snapshot.connectionState == ConnectionState.waiting) {
-                    return CircularProgressIndicator();
-                  } else if (snapshot.hasError) {
-                    return Text('Error getting device info: ${snapshot.error}');
-                  } else if (snapshot.hasData) {
-                    return Text('Device Info: ${snapshot.data}');
-                  } else {
-                    return Text('No data available');
+            FutureBuilder<EnvironmentDetails>(
+              future: PlatformDetail.environmentDetails(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const CircularProgressIndicator();
+                } else if (snapshot.hasError) {
+                  return Text(
+                      'Error getting environment details: ${snapshot.error}');
+                } else if (snapshot.hasData) {
+                  final details = snapshot.data!;
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text('Environment Details:'),
+                      Text('PlatformType: ${details.platformType.name}'),
+                      Text('Platform: ${details.platform}'),
+                      Text('Device Model: ${details.deviceModel}'),
+                      Text('Locale: ${details.locale}'),
+                    ],
+                  );
+                } else {
+                  return const Text('No environment details available');
+                }
+              },
+            ),
+            const SizedBox(height: 16),
+            FutureBuilder<String>(
+              future: PlatformDetail.deviceInfoDetails(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const CircularProgressIndicator();
+                } else if (snapshot.hasError) {
+                  return Text('Error getting device info: ${snapshot.error}');
+                } else if (snapshot.hasData) {
+                  return Text('Device Info: ${snapshot.data}');
+                } else {
+                  return const Text('No data available');
+                }
+              },
+            ),
+            const SizedBox(height: 16),
+            FutureBuilder<List<String>>(
+              future: PlatformDetail.getPrivateIp,
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const CircularProgressIndicator();
+                } else if (snapshot.hasError) {
+                  return Text('Error getting private IP: ${snapshot.error}');
+                } else if (snapshot.hasData) {
+                  if (snapshot.data!.isEmpty) {
+                    return const Text('Private IP: Unavailable');
                   }
-                }),
-            FutureBuilder(
-                future: PlatformDetail.getPrivateIp,
-                builder: (context, snapshot) {
-                  if (snapshot.connectionState == ConnectionState.waiting) {
-                    return CircularProgressIndicator();
-                  } else if (snapshot.hasError) {
-                    return Text('Error getting private IP: ${snapshot.error}');
-                  } else if (snapshot.hasData) {
-                    if (snapshot.data!.isEmpty) {
-                      return Text('Private IP: Unavailable');
-                    }
-                    return Text('Private IP: ${snapshot.data}');
-                  } else {
-                    return Text('No private IP available');
-                  }
-                }),
-            FutureBuilder(
-                future: PlatformDetail.getPublicIp,
-                builder: (context, snapshot) {
-                  if (snapshot.connectionState == ConnectionState.waiting) {
-                    return CircularProgressIndicator();
-                  } else if (snapshot.hasError) {
-                    return Text('Error getting public IP: ${snapshot.error}');
-                  } else if (snapshot.hasData) {
-                    return Text('Public IP: ${snapshot.data}');
-                  } else {
-                    return Text('No public IP available');
-                  }
-                }),
+                  return Text('Private IP: ${snapshot.data}');
+                } else {
+                  return const Text('No private IP available');
+                }
+              },
+            ),
+            const SizedBox(height: 16),
+            FutureBuilder<String?>(
+              future: PlatformDetail.getPublicIp,
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const CircularProgressIndicator();
+                } else if (snapshot.hasError) {
+                  return Text('Error getting public IP: ${snapshot.error}');
+                } else if (snapshot.hasData) {
+                  return Text('Public IP: ${snapshot.data}');
+                } else {
+                  return const Text('No public IP available');
+                }
+              },
+            ),
           ],
         ),
       ),

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -152,6 +153,7 @@
 		33CEB47122A05771004F2AC0 /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */,
 				33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */,
 				33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */,
@@ -461,7 +463,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -543,7 +545,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -593,7 +595,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -214,7 +214,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "5.1.0"
+    version: "5.2.0"
   plugin_platform_interface:
     dependency: transitive
     description:

--- a/lib/platform_detail.dart
+++ b/lib/platform_detail.dart
@@ -1,4 +1,5 @@
 export 'src/device_theme.dart';
+export 'src/environment_details.dart';
 export 'src/platform_detail.dart';
 export 'src/platform_group.dart';
 export 'src/platform_type.dart';

--- a/lib/src/environment_details.dart
+++ b/lib/src/environment_details.dart
@@ -1,0 +1,16 @@
+import 'platform_type.dart';
+
+/// Typed wrapper for lightweight runtime environment details.
+class EnvironmentDetails {
+  const EnvironmentDetails({
+    required this.platformType,
+    required this.platform,
+    required this.deviceModel,
+    required this.locale,
+  });
+
+  final PlatformType platformType;
+  final String platform;
+  final String deviceModel;
+  final String locale;
+}

--- a/lib/src/platform_detail.dart
+++ b/lib/src/platform_detail.dart
@@ -38,14 +38,7 @@ class PlatformDetail {
 
   /// Returns an enum with the group of platform related.
   static PlatformGroup get currentGroupPlatform {
-    if (isWeb) {
-      return PlatformGroup.web;
-    } else if (isDesktop) {
-      return PlatformGroup.desktop;
-    } else if (isMobile) {
-      return PlatformGroup.mobile;
-    }
-    throw Exception('Platform ($defaultTargetPlatform) unrecognized.');
+    return _groupFromPlatform(currentPlatform);
   }
 
   /// Returns the current platform type, including support for web.
@@ -56,14 +49,22 @@ class PlatformDetail {
 
   /// This parameter returns an enum with the group of platform related.
   static PlatformGroup get type {
-    if (isWeb) {
-      return PlatformGroup.web;
-    } else if (isDesktop) {
-      return PlatformGroup.desktop;
-    } else if (isMobile) {
-      return PlatformGroup.mobile;
+    return _groupFromPlatform(currentPlatform);
+  }
+
+  static PlatformGroup _groupFromPlatform(PlatformType platform) {
+    switch (platform) {
+      case PlatformType.web:
+        return PlatformGroup.web;
+      case PlatformType.android:
+      case PlatformType.iOS:
+      case PlatformType.fuchsia:
+        return PlatformGroup.mobile;
+      case PlatformType.macOS:
+      case PlatformType.windows:
+      case PlatformType.linux:
+        return PlatformGroup.desktop;
     }
-    throw Exception('Platform ($defaultTargetPlatform) unrecognized.');
   }
 
   /// Checks if the current platform is a desktop OS.

--- a/lib/src/platform_detail.dart
+++ b/lib/src/platform_detail.dart
@@ -192,6 +192,79 @@ class PlatformDetail {
     }
   }
 
+  /// Returns compact environment details for telemetry and diagnostics.
+  static Future<EnvironmentDetails> environmentDetails() async {
+    final platformType = currentPlatform;
+    final locale = _platformDispatcher.locale.toLanguageTag();
+
+    try {
+      switch (platformType) {
+        case PlatformType.android:
+          final info = await _deviceInfo.androidInfo;
+          return EnvironmentDetails(
+            platformType: platformType,
+            platform: 'android ${info.version.release}',
+            deviceModel: '${info.manufacturer} ${info.model}'.trim(),
+            locale: locale,
+          );
+        case PlatformType.iOS:
+          final info = await _deviceInfo.iosInfo;
+          return EnvironmentDetails(
+            platformType: platformType,
+            platform: 'ios ${info.systemVersion}',
+            deviceModel: info.modelName,
+            locale: locale,
+          );
+        case PlatformType.macOS:
+          final info = await _deviceInfo.macOsInfo;
+          return EnvironmentDetails(
+            platformType: platformType,
+            platform: 'macos ${info.osRelease}',
+            deviceModel: info.modelName,
+            locale: locale,
+          );
+        case PlatformType.windows:
+          final info = await _deviceInfo.windowsInfo;
+          return EnvironmentDetails(
+            platformType: platformType,
+            platform: 'windows ${info.displayVersion}',
+            deviceModel: info.computerName,
+            locale: locale,
+          );
+        case PlatformType.linux:
+          final info = await _deviceInfo.linuxInfo;
+          return EnvironmentDetails(
+            platformType: platformType,
+            platform: 'linux ${info.version}',
+            deviceModel: info.prettyName,
+            locale: locale,
+          );
+        case PlatformType.web:
+          final info = await _deviceInfo.webBrowserInfo;
+          return EnvironmentDetails(
+            platformType: platformType,
+            platform: 'web ${info.browserName.name}',
+            deviceModel: info.platform ?? 'browser',
+            locale: locale,
+          );
+        case PlatformType.fuchsia:
+          return EnvironmentDetails(
+            platformType: platformType,
+            platform: 'fuchsia',
+            deviceModel: 'unknown',
+            locale: locale,
+          );
+      }
+    } catch (_) {
+      return EnvironmentDetails(
+        platformType: platformType,
+        platform: platformType.name,
+        deviceModel: 'unknown',
+        locale: locale,
+      );
+    }
+  }
+
   /// Checks if the device is in Dark Mode.
   static bool get isDarkMode =>
       _platformDispatcher.platformBrightness == Brightness.dark;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: platform_detail
 description: A lightweight library to obtain details of the current platform in a much more complete and simple way.
-version: 5.2.0
+version: 5.3.0
 homepage: https://github.com/vicajilau/platform_detail
 
 environment:

--- a/test/device_info_test.dart
+++ b/test/device_info_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -17,6 +19,8 @@ void main() {
     setUpAll(() {
       mockDeviceInfo = MockDeviceInfoPlugin();
       mockPlatformDispatcher = MockPlatformDispatcher();
+      when(() => mockPlatformDispatcher.locale)
+          .thenReturn(const Locale('es', 'ES'));
       PlatformDetail.forTesting(
           mockDeviceInfo: mockDeviceInfo,
           mockPlatformDispatcher: mockPlatformDispatcher);
@@ -257,6 +261,71 @@ void main() {
       expect(infoDetailString,
           'Fuchsia BaseDeviceInfo{data: {name: Fuchsia Emulator, systemName: Fuchsia, systemVersion: 1.0.0, model: Fuchsia Dev Board, isPhysicalDevice: false}}');
       expect(infoDetail, info);
+    });
+
+    test('environmentDetails uses PlatformType and wrapper on android',
+        () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      final mockMap = {
+        'version': {
+          'sdkInt': 33,
+          'release': '13',
+          'previewSdkInt': 0,
+          'incremental': 'abcd1234',
+          'codename': 'REL',
+          'baseOS': 'android',
+          'securityPatch': '2024-04-01',
+        },
+        'board': 'goldfish_x86_64',
+        'bootloader': 'unknown',
+        'brand': 'google',
+        'device': 'generic_x86_64',
+        'display': 'sdk_gphone_x86_64-userdebug 13',
+        'fingerprint': 'google/sdk_gphone_x86_64',
+        'hardware': 'ranchu',
+        'host': 'abfarm999',
+        'id': 'TQ3A.230805.001.A1',
+        'manufacturer': 'Google',
+        'model': 'Pixel 6 Pro',
+        'product': 'sdk_gphone_x86_64',
+        'name': 'generic_x86_64',
+        'supported32BitAbis': ['x86'],
+        'supported64BitAbis': ['x86_64'],
+        'supportedAbis': ['x86_64', 'x86'],
+        'tags': 'test-keys',
+        'type': 'userdebug',
+        'isPhysicalDevice': false,
+        'systemFeatures': [
+          'android.hardware.camera',
+          'android.hardware.sensor.accelerometer'
+        ],
+        'serialNumber': 'unknown',
+        'isLowRamDevice': false,
+        'freeDiskSize': 128000,
+        'totalDiskSize': 512000,
+        'physicalRamSize': 16,
+        'availableRamSize': 6
+      };
+      final info = AndroidDeviceInfo.fromMap(mockMap);
+
+      when(() => mockDeviceInfo.androidInfo).thenAnswer((_) async => info);
+
+      final details = await PlatformDetail.environmentDetails();
+      expect(details.platformType, PlatformType.android);
+      expect(details.platform, 'android 13');
+      expect(details.deviceModel, 'Google Pixel 6 Pro');
+      expect(details.locale, 'es-ES');
+    });
+
+    test('environmentDetails falls back on plugin error', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      when(() => mockDeviceInfo.iosInfo).thenThrow(Exception('boom'));
+
+      final details = await PlatformDetail.environmentDetails();
+      expect(details.platformType, PlatformType.iOS);
+      expect(details.platform, 'iOS');
+      expect(details.deviceModel, 'unknown');
+      expect(details.locale, 'es-ES');
     });
   });
 }

--- a/test/device_info_test.dart
+++ b/test/device_info_test.dart
@@ -327,5 +327,172 @@ void main() {
       expect(details.deviceModel, 'unknown');
       expect(details.locale, 'es-ES');
     });
+
+    test('environmentDetails returns ios values on success', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      final mockMap = {
+        'name': 'Flutter iPhone',
+        'systemName': 'iOS',
+        'systemVersion': '17.4.1',
+        'model': 'iPhone',
+        'modelName': 'iPhone 14 Pro',
+        'localizedModel': 'iPhone',
+        'identifierForVendor': '12345678-1234-1234-1234-1234567890ab',
+        'isPhysicalDevice': true,
+        'isiOSAppOnMac': false,
+        'utsname': {
+          'sysname': 'Darwin',
+          'nodename': 'iPhone',
+          'release': '23.4.0',
+          'version': 'Darwin Kernel Version 23.4.0',
+          'machine': 'iPhone15,2',
+        },
+        'freeDiskSize': 128000,
+        'totalDiskSize': 512000,
+        'physicalRamSize': 16,
+        'availableRamSize': 6
+      };
+      final info = IosDeviceInfo.fromMap(mockMap);
+
+      when(() => mockDeviceInfo.iosInfo).thenAnswer((_) async => info);
+
+      final details = await PlatformDetail.environmentDetails();
+      expect(details.platformType, PlatformType.iOS);
+      expect(details.platform, 'ios 17.4.1');
+      expect(details.deviceModel, 'iPhone 14 Pro');
+      expect(details.locale, 'es-ES');
+    });
+
+    test('environmentDetails returns macOS values on success', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      final info = MacOsDeviceInfo.fromMap({
+        'computerName': 'MyMac',
+        'hostName': 'mymac.local',
+        'arch': 'x86_64',
+        'model': 'MacBookPro18,3',
+        'modelName': 'MacBook Pro',
+        'kernelVersion': 'Darwin 23.2.0',
+        'osRelease': '23.2.0',
+        'majorVersion': 14,
+        'minorVersion': 2,
+        'patchVersion': 0,
+        'activeCPUs': 8,
+        'memorySize': 17179869184,
+        'cpuFrequency': 2400000000,
+        'systemGUID': 'ABC123-XYZ789'
+      });
+
+      when(() => mockDeviceInfo.macOsInfo).thenAnswer((_) async => info);
+
+      final details = await PlatformDetail.environmentDetails();
+      expect(details.platformType, PlatformType.macOS);
+      expect(details.platform, 'macos 23.2.0');
+      expect(details.deviceModel, 'MacBook Pro');
+      expect(details.locale, 'es-ES');
+    });
+
+    test('environmentDetails returns windows values on success', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      final info = WindowsDeviceInfo(
+        computerName: 'MY-PC',
+        numberOfCores: 8,
+        systemMemoryInMegabytes: 16384,
+        userName: 'TestUser',
+        majorVersion: 10,
+        minorVersion: 0,
+        buildNumber: 22621,
+        platformId: 2,
+        csdVersion: '',
+        servicePackMajor: 0,
+        servicePackMinor: 0,
+        suitMask: 0,
+        productType: 1,
+        reserved: 0,
+        buildLab: '22621.vb_release.191206-1406',
+        buildLabEx: '22621.1.amd64fre.ni_release.210506-1631',
+        digitalProductId: Uint8List.fromList([1, 2, 3, 4]),
+        displayVersion: '22H2',
+        editionId: 'Professional',
+        installDate: DateTime(2020, 1, 1),
+        productId: '00330-80000-00000-AA123',
+        productName: 'Windows 11 Pro',
+        registeredOwner: 'John Doe',
+        releaseId: '2009',
+        deviceId: 'ABCDEF123456',
+      );
+
+      when(() => mockDeviceInfo.windowsInfo).thenAnswer((_) async => info);
+
+      final details = await PlatformDetail.environmentDetails();
+      expect(details.platformType, PlatformType.windows);
+      expect(details.platform, 'windows 22H2');
+      expect(details.deviceModel, 'MY-PC');
+      expect(details.locale, 'es-ES');
+    });
+
+    test('environmentDetails returns linux values on success', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      final info = LinuxDeviceInfo(
+        name: 'Ubuntu',
+        version: '22.04.1 LTS (Jammy Jellyfish)',
+        id: 'ubuntu',
+        idLike: ['debian'],
+        versionCodename: 'jammy',
+        versionId: '22.04',
+        prettyName: 'Ubuntu 22.04.1 LTS',
+        buildId: '2023.04.26',
+        variant: 'Ubuntu Desktop',
+        variantId: 'ubuntu-desktop',
+        machineId: 'abc123-def456-ghi789',
+      );
+
+      when(() => mockDeviceInfo.linuxInfo).thenAnswer((_) async => info);
+
+      final details = await PlatformDetail.environmentDetails();
+      expect(details.platformType, PlatformType.linux);
+      expect(details.platform, 'linux 22.04.1 LTS (Jammy Jellyfish)');
+      expect(details.deviceModel, 'Ubuntu 22.04.1 LTS');
+      expect(details.locale, 'es-ES');
+    });
+
+    test('environmentDetails returns web values on success', () async {
+      PlatformDetail.forTesting(mockedWeb: true);
+      final webInfo = WebBrowserInfo(
+        userAgent: 'Chrome',
+        appVersion: '115.0.5790.170',
+        appCodeName: 'Mozilla',
+        appName: 'Netscape',
+        deviceMemory: 8,
+        language: 'en-US',
+        languages: ['en-US'],
+        platform: 'Win32',
+        product: 'Gecko',
+        productSub: '20030107',
+        vendor: 'GoogleInc.',
+        vendorSub: '',
+        maxTouchPoints: 0,
+        hardwareConcurrency: 4,
+      );
+
+      when(() => mockDeviceInfo.webBrowserInfo)
+          .thenAnswer((_) async => webInfo);
+
+      final details = await PlatformDetail.environmentDetails();
+      expect(details.platformType, PlatformType.web);
+      expect(details.platform, 'web chrome');
+      expect(details.deviceModel, 'Win32');
+      expect(details.locale, 'es-ES');
+      PlatformDetail.forTesting(mockedWeb: false);
+    });
+
+    test('environmentDetails returns fuchsia values on success', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
+
+      final details = await PlatformDetail.environmentDetails();
+      expect(details.platformType, PlatformType.fuchsia);
+      expect(details.platform, 'fuchsia');
+      expect(details.deviceModel, 'unknown');
+      expect(details.locale, 'es-ES');
+    });
   });
 }


### PR DESCRIPTION
This pull request introduces a new typed wrapper for runtime environment metadata, exposes a new API for retrieving compact environment details, updates the example app to display these details, and adds related documentation and tests. It also includes some minor project configuration changes.

**New Environment Details Feature:**

* Added the `EnvironmentDetails` class as a typed wrapper for lightweight runtime environment metadata, including platform, device model, locale, and platform type. (`lib/src/environment_details.dart`, `lib/platform_detail.dart`) 
* Introduced `PlatformDetail.environmentDetails()` static method to retrieve an `EnvironmentDetails` object with platform, model, locale, and platform type, including robust fallback logic. (`lib/src/platform_detail.dart`)
* Exported `EnvironmentDetails` from the public API. (`lib/platform_detail.dart`)

**Documentation and Example Updates:**

* Updated `README.md` to document the new `environmentDetails()` API, its usage, and the new fields available. Also clarified the static API usage and updated the example app instructions. 
* Updated the example app (`example/lib/main.dart`) to render `EnvironmentDetails` on screen, using a `FutureBuilder` for asynchronous loading and improved layout.
* Added a VS Code launch configuration for running the example app. (`.vscode/launch.json`)

**Testing and Changelog:**

* Added tests for `environmentDetails()` success and fallback flows, including locale mocking. (`test/device_info_test.dart`) 
* Updated `CHANGELOG.md` and bumped the package version to 5.3.0. (`CHANGELOG.md`, `pubspec.yaml`) 

**Internal Refactoring:**

* Refactored platform group detection to use a private `_groupFromPlatform()` helper for improved maintainability. (`lib/src/platform_detail.dart`) 

**Project Configuration:**

* Updated macOS deployment target to 10.15 and added a Swift package reference in the example app's Xcode project. (`example/macos/Runner.xcodeproj/project.pbxproj`) 