### PR TITLE
Add version details functionality and update example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,27 @@ This returns an `EnvironmentDetails` object with these fields:
 The `example` app includes a section that renders these values on screen.
 ---
 
+### Get app version and build number
+If you need app package metadata, you can use `versionDetails()`:
+
+```dart
+void main() async {
+  final details = await PlatformDetail.versionDetails();
+
+  print(details.appName); // My App
+  print(details.packageName); // com.example.my_app
+  print(details.version); // 5.4.0
+  print(details.buildNumber); // 12
+}
+```
+
+This returns a `VersionDetails` object with these fields:
+- `appName`: `String`
+- `packageName`: `String`
+- `version`: `String`
+- `buildNumber`: `String`
+---
+
 ### Light/Dark Mode
 You can detect too if the device is configured in light or dark mode:
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -87,6 +87,31 @@ class _MyHomePageState extends State<MyHomePage> {
               },
             ),
             const SizedBox(height: 16),
+            FutureBuilder<VersionDetails>(
+              future: PlatformDetail.versionDetails(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const CircularProgressIndicator();
+                } else if (snapshot.hasError) {
+                  return Text('Error getting app details: ${snapshot.error}');
+                } else if (snapshot.hasData) {
+                  final details = snapshot.data!;
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text('App Details:'),
+                      Text('App Name: ${details.appName}'),
+                      Text('Package Name: ${details.packageName}'),
+                      Text('Version: ${details.version}'),
+                      Text('Build Number: ${details.buildNumber}'),
+                    ],
+                  );
+                } else {
+                  return const Text('No app details available');
+                }
+              },
+            ),
+            const SizedBox(height: 16),
             FutureBuilder<List<String>>(
               future: PlatformDetail.getPrivateIp,
               builder: (context, snapshot) {

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,9 @@ import FlutterMacOS
 import Foundation
 
 import device_info_plus
+import package_info_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: dio_web_adapter
-      sha256: "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78"
+      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   fake_async:
     dependency: transitive
     description:
@@ -128,6 +128,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
   http_parser:
     dependency: transitive
     description:
@@ -164,10 +172,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: a5e2b223cb7c9c8efdc663ef484fdd95bb243bff242ef5b13e26883547fce9a0
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "6.1.0"
   matcher:
     dependency: transitive
     description:
@@ -200,6 +208,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:
@@ -214,7 +238,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "5.2.0"
+    version: "5.4.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -232,10 +256,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   stack_trace:
     dependency: transitive
     description:
@@ -296,18 +320,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "15.0.2"
   web:
     dependency: transitive
     description:
       name: web
-      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   win32:
     dependency: transitive
     description:

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -1,10 +1,3 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -58,12 +51,22 @@ void main() {
         find.text('No private IP available').evaluate().isNotEmpty ||
         find.text('Private IP: Unavailable').evaluate().isNotEmpty;
 
+    final hasAppDetailsState = hasLoadingState ||
+        find.textContaining('App Details:').evaluate().isNotEmpty ||
+        find.textContaining('App Name:').evaluate().isNotEmpty ||
+        find.textContaining('Package Name:').evaluate().isNotEmpty ||
+        find.textContaining('Version:').evaluate().isNotEmpty ||
+        find.textContaining('Build Number:').evaluate().isNotEmpty ||
+        find.textContaining('No app details available').evaluate().isNotEmpty ||
+        find.textContaining('Error getting app details:').evaluate().isNotEmpty;
+
     final hasPublicIpState = hasLoadingState ||
         find.textContaining('Public IP:').evaluate().isNotEmpty ||
         find.textContaining('Error getting public IP:').evaluate().isNotEmpty ||
         find.text('No public IP available').evaluate().isNotEmpty;
 
     expect(hasDeviceInfoState, isTrue);
+    expect(hasAppDetailsState, isTrue);
     expect(hasPrivateIpState, isTrue);
     expect(hasPublicIpState, isTrue);
   });

--- a/lib/platform_detail.dart
+++ b/lib/platform_detail.dart
@@ -3,3 +3,4 @@ export 'src/environment_details.dart';
 export 'src/platform_detail.dart';
 export 'src/platform_group.dart';
 export 'src/platform_type.dart';
+export 'src/version_details.dart';

--- a/lib/src/platform_detail.dart
+++ b/lib/src/platform_detail.dart
@@ -1,5 +1,6 @@
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:platform_detail/src/target_platform_extension.dart';
 
@@ -20,6 +21,8 @@ class PlatformDetail {
       SchedulerBinding.instance.platformDispatcher;
 
   static NetworkUtils _networkUtils = NetworkUtils();
+  static Future<PackageInfo> Function() _packageInfoProvider =
+      PackageInfo.fromPlatform;
   static bool _mockedWeb = false;
 
   /// Testing purposes!!!
@@ -28,11 +31,13 @@ class PlatformDetail {
     DeviceInfoPlugin? mockDeviceInfo,
     PlatformDispatcher? mockPlatformDispatcher,
     NetworkUtils? mockNetworkUtils,
+    Future<PackageInfo> Function()? mockPackageInfoProvider,
     mockedWeb = false,
   }) {
     _deviceInfo = mockDeviceInfo ?? _deviceInfo;
     _platformDispatcher = mockPlatformDispatcher ?? _platformDispatcher;
     _networkUtils = mockNetworkUtils ?? _networkUtils;
+    _packageInfoProvider = mockPackageInfoProvider ?? _packageInfoProvider;
     _mockedWeb = mockedWeb;
   }
 
@@ -263,6 +268,28 @@ class PlatformDetail {
         deviceModel: 'unknown',
         locale: locale,
       );
+    }
+  }
+
+  /// Returns app package metadata (`appName`, `packageName`, `version` and `buildNumber`).
+  static Future<VersionDetails> versionDetails() async {
+    return VersionDetails(
+      appName: await _safePackageInfoValue((info) => info.appName),
+      packageName: await _safePackageInfoValue((info) => info.packageName),
+      version: await _safePackageInfoValue((info) => info.version),
+      buildNumber: await _safePackageInfoValue((info) => info.buildNumber),
+    );
+  }
+
+  static Future<String> _safePackageInfoValue(
+    String Function(PackageInfo info) valueSelector,
+  ) async {
+    try {
+      final info = await _packageInfoProvider();
+      final value = valueSelector(info).trim();
+      return value.isEmpty ? 'unknown' : value;
+    } catch (_) {
+      return 'unknown';
     }
   }
 

--- a/lib/src/version_details.dart
+++ b/lib/src/version_details.dart
@@ -1,0 +1,14 @@
+/// Typed wrapper for app package metadata.
+class VersionDetails {
+  const VersionDetails({
+    required this.appName,
+    required this.packageName,
+    required this.version,
+    required this.buildNumber,
+  });
+
+  final String appName;
+  final String packageName;
+  final String version;
+  final String buildNumber;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -120,6 +120,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
   http_parser:
     dependency: transitive
     description:
@@ -200,6 +208,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: platform_detail
 description: A lightweight library to obtain details of the current platform in a much more complete and simple way.
-version: 5.3.0
+version: 5.4.0
 homepage: https://github.com/vicajilau/platform_detail
 
 environment:
@@ -10,6 +10,7 @@ environment:
 dependencies:
   device_info_plus: ^12.3.0
   dio: ^5.9.2
+  package_info_plus: ^9.0.0
   flutter:
     sdk: flutter
 

--- a/test/version_details_test.dart
+++ b/test/version_details_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:platform_detail/platform_detail.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('VersionDetails Tests', () {
+    test('versionDetails returns app package metadata', () async {
+      Future<PackageInfo> mockProvider() async {
+        return PackageInfo(
+          appName: 'platform_detail_example',
+          packageName: 'com.example.platform_detail_example',
+          version: '5.4.0',
+          buildNumber: '12',
+          buildSignature: 'abc',
+          installerStore: 'store',
+        );
+      }
+
+      PlatformDetail.forTesting(mockPackageInfoProvider: mockProvider);
+
+      final details = await PlatformDetail.versionDetails();
+
+      expect(details.appName, 'platform_detail_example');
+      expect(details.packageName, 'com.example.platform_detail_example');
+      expect(details.version, '5.4.0');
+      expect(details.buildNumber, '12');
+    });
+
+    test('versionDetails returns fallback values on error', () async {
+      Future<PackageInfo> mockProvider() async {
+        throw Exception('package info error');
+      }
+
+      PlatformDetail.forTesting(mockPackageInfoProvider: mockProvider);
+
+      final details = await PlatformDetail.versionDetails();
+
+      expect(details.appName, 'unknown');
+      expect(details.packageName, 'unknown');
+      expect(details.version, 'unknown');
+      expect(details.buildNumber, 'unknown');
+    });
+
+    test('versionDetails handles field resolution independently', () async {
+      var callCount = 0;
+
+      Future<PackageInfo> mockProvider() async {
+        callCount++;
+        if (callCount == 2) {
+          throw Exception('package name read failed');
+        }
+
+        return PackageInfo(
+          appName: 'platform_detail_example',
+          packageName: 'com.example.platform_detail_example',
+          version: '5.4.0',
+          buildNumber: '12',
+          buildSignature: 'abc',
+          installerStore: 'store',
+        );
+      }
+
+      PlatformDetail.forTesting(mockPackageInfoProvider: mockProvider);
+
+      final details = await PlatformDetail.versionDetails();
+
+      expect(details.appName, 'platform_detail_example');
+      expect(details.packageName, 'unknown');
+      expect(details.version, '5.4.0');
+      expect(details.buildNumber, '12');
+    });
+  });
+}


### PR DESCRIPTION
- Implement `versionDetails()` method to retrieve app package metadata.
- Create `VersionDetails` class to encapsulate app details.
- Update example app to display app version and build number.
- Add tests for `versionDetails()` to ensure correct functionality.
- Update dependencies in pubspec.yaml and pubspec.lock.